### PR TITLE
ForgeEvents: Only send clientbound packet on server

### DIFF
--- a/src/main/java/net/abraxator/moresnifferflowers/events/ForgeEvents.java
+++ b/src/main/java/net/abraxator/moresnifferflowers/events/ForgeEvents.java
@@ -80,7 +80,7 @@ public class ForgeEvents {
         Holder<MobEffect> effect = event.getEffectInstance().getEffect();
         LivingEntity entity = event.getEntity();
 
-        if (effect.equals(ModEffects.GLUED)){
+        if (!entity.level().isClientSide() && effect.equals(ModEffects.GLUED)){
             GluedCapability.setAndSync(entity, true, true);
         }
     }


### PR DESCRIPTION
Fixes client crash with this stacktrace:

```
java.lang.NullPointerException: Cannot send clientbound payloads on the client
	at java.base/java.util.Objects.requireNonNull(Objects.java:259) 
	at TRANSFORMER/neoforge@21.1.218/net.neoforged.neoforge.network.PacketDistributor.sendToAllPlayers(PacketDistributor.java:82) 
	at TRANSFORMER/moresnifferflowers@6.6.1/net.abraxator.moresnifferflowers.capability.GluedCapability.sync(GluedCapability.java:37) 
	at TRANSFORMER/moresnifferflowers@6.6.1/net.abraxator.moresnifferflowers.capability.GluedCapability.setAndSync(GluedCapability.java:33) 
	at TRANSFORMER/moresnifferflowers@6.6.1/net.abraxator.moresnifferflowers.events.ForgeEvents.onEffectAdded(ForgeEvents.java:84) 
	at MC-BOOTSTRAP/net.neoforged.bus/net.neoforged.bus.EventBus.post(EventBus.java:360)
	at MC-BOOTSTRAP/net.neoforged.bus/net.neoforged.bus.EventBus.post(EventBus.java:328)
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.LivingEntity.addEffect(LivingEntity.java:956) 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.LivingEntity.addEffect(LivingEntity.java:947) 
	at TRANSFORMER/moresnifferflowers@6.6.1/net.abraxator.moresnifferflowers.blocks.TorchewflowerBlock.entityInside(TorchewflowerBlock.java:76) 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.entityInside(BlockBehaviour.java:740) 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.checkInsideBlocks(Entity.java:1030) 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.tryCheckInsideBlocks(Entity.java:771) 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.move(Entity.java:716)
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.player.Player.move(Player.java:30912)
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.player.LocalPlayer.move(LocalPlayer.java:915)
```

It would be better to only apply the MobEffect on the server, where it will automatically be synced to the client, but this is a bandaid fix.